### PR TITLE
fix: Create a new LAContext every time we need to access it

### DIFF
--- a/Sources/InfomaniakCoreUI/Security/AppLockHelper.swift
+++ b/Sources/InfomaniakCoreUI/Security/AppLockHelper.swift
@@ -25,11 +25,12 @@ public final class AppLockHelper {
     private var timeSinceAppEnteredBackground = TimeInterval.zero
 
     public var isAppLocked: Bool {
-        return timeSinceAppEnteredBackground + intervalToLockApp < Date().timeIntervalSince1970
+        let shouldBeLocked = timeSinceAppEnteredBackground + intervalToLockApp < Date().timeIntervalSince1970
+        return isAvailable() && shouldBeLocked
     }
 
-    public init(unlockTime: TimeInterval = AppLockHelper.lockAfterOneMinute) {
-        self.intervalToLockApp = unlockTime
+    public init(intervalToLockApp: TimeInterval = AppLockHelper.lockAfterOneMinute) {
+        self.intervalToLockApp = intervalToLockApp
     }
 
     public func isAvailable(_ context: LAContext? = nil) -> Bool {


### PR DESCRIPTION
On macOS, we need to create the LAContext every time we want to access it.
We should also check if we can evaluate the policy in order to lock the app.