### PR TITLE
feat: Add inactive Style for FAB if user doesn't have canSendEmails permission

### DIFF
--- a/Sources/InfomaniakCoreSwiftUI/Components/Buttons/IKFloatingActionButtonStyle.swift
+++ b/Sources/InfomaniakCoreSwiftUI/Components/Buttons/IKFloatingActionButtonStyle.swift
@@ -27,7 +27,7 @@ public struct IKFloatingActionButtonStyle: ButtonStyle {
 
     var isExtended = false
     var customSize: CGFloat?
-    var isInactive: Bool = false
+    var isInactive = false
 
     private var size: CGFloat {
         if let customSize {
@@ -54,7 +54,11 @@ public struct IKFloatingActionButtonStyle: ButtonStyle {
 
 @available(iOS 15.0, *)
 public extension ButtonStyle where Self == IKFloatingActionButtonStyle {
-    static func ikFloatingActionButton(isExtended: Bool = false, customSize: CGFloat? = nil, isInactive: Bool = false) -> IKFloatingActionButtonStyle {
+    static func ikFloatingActionButton(
+        isExtended: Bool = false,
+        customSize: CGFloat? = nil,
+        isInactive: Bool = false
+    ) -> IKFloatingActionButtonStyle {
         return IKFloatingActionButtonStyle(isExtended: isExtended, customSize: customSize, isInactive: isInactive)
     }
 

--- a/Sources/InfomaniakCoreSwiftUI/Components/Buttons/IKFloatingActionButtonStyle.swift
+++ b/Sources/InfomaniakCoreSwiftUI/Components/Buttons/IKFloatingActionButtonStyle.swift
@@ -27,6 +27,7 @@ public struct IKFloatingActionButtonStyle: ButtonStyle {
 
     var isExtended = false
     var customSize: CGFloat?
+    var isInactive: Bool = false
 
     private var size: CGFloat {
         if let customSize {
@@ -45,7 +46,7 @@ public struct IKFloatingActionButtonStyle: ButtonStyle {
             .font(theme.mediumFont)
             .padding(.horizontal, IKPadding.medium)
             .frame(minWidth: isExtended ? nil : size, minHeight: size)
-            .modifier(IKButtonFilledModifier(buttonRole: configuration.role, isProminent: true))
+            .modifier(IKButtonFilledModifier(buttonRole: configuration.role, isProminent: true, isInactive: isInactive))
             .modifier(IKButtonScaleAnimationModifier(isPressed: configuration.isPressed))
             .allowsHitTesting(!isLoading)
     }
@@ -53,8 +54,8 @@ public struct IKFloatingActionButtonStyle: ButtonStyle {
 
 @available(iOS 15.0, *)
 public extension ButtonStyle where Self == IKFloatingActionButtonStyle {
-    static func ikFloatingActionButton(isExtended: Bool = false, customSize: CGFloat? = nil) -> IKFloatingActionButtonStyle {
-        return IKFloatingActionButtonStyle(isExtended: isExtended, customSize: customSize)
+    static func ikFloatingActionButton(isExtended: Bool = false, customSize: CGFloat? = nil, isInactive: Bool = false) -> IKFloatingActionButtonStyle {
+        return IKFloatingActionButtonStyle(isExtended: isExtended, customSize: customSize, isInactive: isInactive)
     }
 
     static var ikFloatingActionButton: IKFloatingActionButtonStyle {

--- a/Sources/InfomaniakCoreSwiftUI/Components/Buttons/Modifiers/IKButtonModifiers.swift
+++ b/Sources/InfomaniakCoreSwiftUI/Components/Buttons/Modifiers/IKButtonModifiers.swift
@@ -142,20 +142,22 @@ public struct IKButtonFilledModifier: ViewModifier {
 
     let buttonRole: ButtonRole?
     let isProminent: Bool
+    let isInactive: Bool
 
     private var isDisabled: Bool {
         return !isEnabled || isLoading
     }
 
     private var foregroundStyle: any ShapeStyle {
-        guard !isDisabled else {
+        if isDisabled || isInactive {
             return theme.disabledSecondary
+        } else {
+            return isProminent ? theme.secondary : theme.primary
         }
-        return isProminent ? theme.secondary : theme.primary
     }
 
     private var backgroundStyle: any ShapeStyle {
-        if isDisabled {
+        if isDisabled || isInactive {
             return theme.disabledPrimary
         } else if buttonRole == .destructive {
             return theme.error
@@ -164,9 +166,10 @@ public struct IKButtonFilledModifier: ViewModifier {
         }
     }
 
-    public init(buttonRole: ButtonRole?, isProminent: Bool) {
+    public init(buttonRole: ButtonRole?, isProminent: Bool, isInactive: Bool = false) {
         self.buttonRole = buttonRole
         self.isProminent = isProminent
+        self.isInactive = isInactive
     }
 
     public func body(content: Content) -> some View {


### PR DESCRIPTION
When an administrator disables mail sending for a user, the compose button remains tappable. Tapping it displays a snackbar informing the user that the administrator has disabled mail sending capability.