### PR TITLE
ci: Replace pull_request_target with pull_request in GitHub Actions

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -7,7 +7,7 @@ on:
       - edited
       - closed
       - reopened
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -24,5 +24,6 @@ concurrency:
 
 jobs:
   check_dependencies:
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.full_name == github.repository
     uses: infomaniak/.github/.github/workflows/dependent-issues.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Description

Replace `pull_request_target` with `pull_request` in GitHub Actions workflows.

### Why

`pull_request_target` runs in the context of the base branch with full access to repository secrets, even for fork PRs. This is unnecessary and a potential security risk for workflows that only need read access (semantic commit check, dependent issues, auto-author assign).

Since all PRs come from within the organization, `pull_request` is sufficient.

### Changes
- `.github/workflows/dependent-issues.yml` (if present):  `pull_request_target` → `pull_request`
- `.github/workflows/auto-author-assign.yml` (if present):  `pull_request_target` → `pull_request`
- `.github/workflows/semantic-commit.yml` (if present): `pull_request_target` → `pull_request`